### PR TITLE
Add core entities, controllers, and configs for Q&A service

### DIFF
--- a/Backend/chat-manage-service/.gitignore
+++ b/Backend/chat-manage-service/.gitignore
@@ -18,6 +18,7 @@ target/
 *.iws
 *.iml
 *.ipr
+.env
 
 ### NetBeans ###
 /nbproject/private/

--- a/Backend/chat-manage-service/pom.xml
+++ b/Backend/chat-manage-service/pom.xml
@@ -55,6 +55,40 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<!-- OpenAPI Documentation -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.7.0</version>
+		</dependency>
+
+		<!-- JSON Processing -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+
+		<!-- File Upload -->
+		<dependency>
+			<groupId>commons-fileupload</groupId>
+			<artifactId>commons-fileupload</artifactId>
+			<version>1.5</version>
+		</dependency>
+
+		<!-- HTML Sanitizer -->
+		<dependency>
+			<groupId>org.jsoup</groupId>
+			<artifactId>jsoup</artifactId>
+			<version>1.16.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
@@ -63,6 +97,15 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.cdimascio</groupId>
+			<artifactId>java-dotenv</artifactId>
+			<version>5.2.2</version> <!-- Check for the latest version -->
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-mongodb</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/ChatManageServiceApplication.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/ChatManageServiceApplication.java
@@ -1,12 +1,21 @@
 package com.stackit.chat_manage_service;
 
+import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @SpringBootApplication
+@EnableJpaAuditing
+@EnableAsync
+@EnableTransactionManagement
 public class ChatManageServiceApplication {
 
 	public static void main(String[] args) {
+		Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+		dotenv.entries().forEach(entry -> System.setProperty(entry.getKey(), entry.getValue()));
 		SpringApplication.run(ChatManageServiceApplication.class, args);
 	}
 

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Config/DataSizeConverter.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Config/DataSizeConverter.java
@@ -1,0 +1,31 @@
+package com.stackit.chat_manage_service.Config;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class DataSizeConverter implements Converter<String, Long> {
+    @Override
+    public Long convert(String source) {
+        if (!StringUtils.hasLength(source)) {
+            return null;
+        }
+
+        source = source.toUpperCase();
+        long multiplier = 1;
+
+        if (source.endsWith("KB")) {
+            multiplier = 1024;
+            source = source.substring(0, source.length() - 2);
+        } else if (source.endsWith("MB")) {
+            multiplier = 1024 * 1024;
+            source = source.substring(0, source.length() - 2);
+        } else if (source.endsWith("GB")) {
+            multiplier = 1024 * 1024 * 1024;
+            source = source.substring(0, source.length() - 2);
+        }
+
+        return Long.parseLong(source) * multiplier;
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Config/JpaConfig.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Config/JpaConfig.java
@@ -1,0 +1,10 @@
+//package com.stackit.chat_manage_service.Config;
+//
+//
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+//
+//@Configuration
+//@EnableJpaRepositories(basePackages = "com.stackit.chat_manage_service.Repository")
+//public class JpaConfig {
+//}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Config/OpenApiConfig.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Config/OpenApiConfig.java
@@ -1,0 +1,43 @@
+package com.stackit.chat_manage_service.Config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Value("${server.port:7000}")
+    private String serverPort;
+
+    @Bean
+    public OpenAPI stackItOpenAPI() {
+        Server devServer = new Server();
+        devServer.setUrl("http://localhost:" + serverPort + "/api");
+        devServer.setDescription("Development Server");
+
+        Contact contact = new Contact();
+        contact.setEmail("support@stackit.com");
+        contact.setName("StackIt Support");
+        contact.setUrl("https://stackit.com");
+
+        License license = new License().name("MIT License").url("https://choosealicense.com/licenses/mit/");
+
+        Info info = new Info()
+                .title("StackIt Q&A Platform API")
+                .version("1.0.0")
+                .contact(contact)
+                .description("RESTful API for StackIt - A minimal question-and-answer platform")
+                .termsOfService("https://stackit.com/terms")
+                .license(license);
+
+        return new OpenAPI().info(info).servers(List.of(devServer));
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Config/WebSocketConfig.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Config/WebSocketConfig.java
@@ -1,0 +1,44 @@
+package com.stackit.chat_manage_service.Config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic");
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/chat")
+                .setAllowedOrigins("http://localhost:5174","http://localhost:5173","http://localhost:1818")
+                .withSockJS();
+    }
+
+    @Bean
+    public UrlBasedCorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:5173","http://localhost:5173"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Accept"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Controller/AnswerController.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Controller/AnswerController.java
@@ -1,0 +1,103 @@
+package com.stackit.chat_manage_service.Controller;
+
+import com.stackit.chat_manage_service.Payload.Request.CreateAnswerRequest;
+import com.stackit.chat_manage_service.Payload.Response.AnswerResponse;
+import com.stackit.chat_manage_service.Service.AnswerService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/answers")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Answers", description = "Answer management operations")
+public class AnswerController {
+
+    private final AnswerService answerService;
+
+    @PostMapping
+    @Operation(summary = "Create a new answer", description = "Post an answer to a question")
+    public ResponseEntity<AnswerResponse> createAnswer(
+            @Valid @RequestBody CreateAnswerRequest request) {
+
+        log.info("Creating answer for question: {}", request.getQuestionId());
+        AnswerResponse response = answerService.createAnswer(request);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Get answer by ID", description = "Retrieve a specific answer by its ID")
+    public ResponseEntity<AnswerResponse> getAnswer(
+            @Parameter(description = "Answer ID") @PathVariable Long id,
+            @Parameter(description = "Current user ID for personalization") @RequestParam(required = false) Long currentUserId) {
+
+        AnswerResponse response = answerService.getAnswerById(id, currentUserId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/question/{questionId}")
+    @Operation(summary = "Get answers for question", description = "Retrieve all answers for a specific question")
+    public ResponseEntity<List<AnswerResponse>> getAnswersByQuestion(
+            @Parameter(description = "Question ID") @PathVariable Long questionId,
+            @Parameter(description = "Current user ID for personalization") @RequestParam(required = false) Long currentUserId) {
+
+        List<AnswerResponse> response = answerService.getAnswersByQuestion(questionId, currentUserId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/user/{userId}")
+    @Operation(summary = "Get answers by user", description = "Retrieve paginated answers posted by a specific user")
+    public ResponseEntity<Page<AnswerResponse>> getAnswersByUser(
+            @Parameter(description = "User ID") @PathVariable Long userId,
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<AnswerResponse> response = answerService.getAnswersByUser(userId, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Update answer", description = "Update an existing answer (only by answer author)")
+    public ResponseEntity<AnswerResponse> updateAnswer(
+            @Parameter(description = "Answer ID") @PathVariable Long id,
+            @Valid @RequestBody CreateAnswerRequest request,
+            @Parameter(description = "Current user ID") @RequestParam Long currentUserId) {
+
+        AnswerResponse response = answerService.updateAnswer(id, request, currentUserId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{id}/accept")
+    @Operation(summary = "Accept answer", description = "Mark an answer as accepted (only by question owner)")
+    public ResponseEntity<Void> acceptAnswer(
+            @Parameter(description = "Answer ID") @PathVariable Long id,
+            @Parameter(description = "Current user ID") @RequestParam Long currentUserId) {
+
+        answerService.acceptAnswer(id, currentUserId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Delete answer", description = "Soft delete an answer (only by answer author)")
+    public ResponseEntity<Void> deleteAnswer(
+            @Parameter(description = "Answer ID") @PathVariable Long id,
+            @Parameter(description = "Current user ID") @RequestParam Long currentUserId) {
+
+        answerService.deleteAnswer(id, currentUserId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Controller/ChatController.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Controller/ChatController.java
@@ -1,0 +1,4 @@
+package com.stackit.chat_manage_service.Controller;
+
+public class ChatController {
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Controller/FileController.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Controller/FileController.java
@@ -1,0 +1,125 @@
+package com.stackit.chat_manage_service.Controller;
+
+import com.stackit.chat_manage_service.Service.FileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/files")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Files", description = "File upload and management operations")
+public class FileController {
+
+    private final FileService fileService;
+
+    @PostMapping("/upload")
+    @Operation(summary = "Upload file", description = "Upload an image file for use in rich text content")
+    public ResponseEntity<Map<String, Object>> uploadFile(
+            @Parameter(description = "File to upload") @RequestParam("file") MultipartFile file) {
+
+        try {
+            log.info("Uploading file: {}", file.getOriginalFilename());
+            String filePath = fileService.uploadFile(file);
+            String fileUrl = fileService.getFileUrl(filePath);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", true);
+            response.put("message", "File uploaded successfully");
+            response.put("fileName", file.getOriginalFilename());
+            response.put("filePath", filePath);
+            response.put("fileUrl", fileUrl);
+            response.put("fileSize", file.getSize());
+            response.put("contentType", file.getContentType());
+
+            return new ResponseEntity<>(response, HttpStatus.CREATED);
+
+        } catch (IOException e) {
+            log.error("Error uploading file: {}", e.getMessage(), e);
+
+            Map<String, Object> errorResponse = new HashMap<>();
+            errorResponse.put("success", false);
+            errorResponse.put("message", "Failed to upload file: " + e.getMessage());
+
+            return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (RuntimeException e) {
+            log.error("Validation error uploading file: {}", e.getMessage());
+
+            Map<String, Object> errorResponse = new HashMap<>();
+            errorResponse.put("success", false);
+            errorResponse.put("message", e.getMessage());
+
+            return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @GetMapping("/{year}/{month}/{day}/{filename:.+}")
+    @Operation(summary = "Get file", description = "Retrieve an uploaded file")
+    public ResponseEntity<ByteArrayResource> getFile(
+            @Parameter(description = "Year") @PathVariable String year,
+            @Parameter(description = "Month") @PathVariable String month,
+            @Parameter(description = "Day") @PathVariable String day,
+            @Parameter(description = "Filename") @PathVariable String filename) {
+
+        try {
+            String filePath = String.format("%s/%s/%s/%s", year, month, day, filename);
+            byte[] fileData = fileService.getFile(filePath);
+
+            ByteArrayResource resource = new ByteArrayResource(fileData);
+
+            // Determine content type based on file extension
+            String contentType = determineContentType(filename);
+
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType(contentType))
+                    .contentLength(fileData.length)
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + filename + "\"")
+                    .body(resource);
+
+        } catch (IOException e) {
+            log.error("Error retrieving file: {}", e.getMessage(), e);
+            return ResponseEntity.notFound().build();
+        } catch (RuntimeException e) {
+            log.error("Error retrieving file: {}", e.getMessage());
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @GetMapping("/info")
+    @Operation(summary = "Get upload info", description = "Get file upload constraints and allowed types")
+    public ResponseEntity<Map<String, Object>> getUploadInfo() {
+        Map<String, Object> info = new HashMap<>();
+        info.put("maxFileSize", fileService.getMaxFileSize());
+        info.put("maxFileSizeMB", fileService.getMaxFileSize() / 1024 / 1024);
+        info.put("allowedTypes", fileService.getAllowedTypes());
+
+        return ResponseEntity.ok(info);
+    }
+
+    private String determineContentType(String filename) {
+        String extension = filename.substring(filename.lastIndexOf(".") + 1).toLowerCase();
+
+        return switch (extension) {
+            case "jpg", "jpeg" -> "image/jpeg";
+            case "png" -> "image/png";
+            case "gif" -> "image/gif";
+            case "webp" -> "image/webp";
+            case "svg" -> "image/svg+xml";
+            default -> "application/octet-stream";
+        };
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Controller/NotificationController.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Controller/NotificationController.java
@@ -1,0 +1,93 @@
+package com.stackit.chat_manage_service.Controller;
+
+import com.stackit.chat_manage_service.Payload.Response.NotificationResponse;
+import com.stackit.chat_manage_service.Service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Notifications", description = "Notification management operations")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping("/user/{userId}")
+    @Operation(summary = "Get user notifications", description = "Retrieve paginated notifications for a user")
+    public ResponseEntity<Page<NotificationResponse>> getUserNotifications(
+            @Parameter(description = "User ID") @PathVariable Long userId,
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<NotificationResponse> response = notificationService.getUserNotifications(userId, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/user/{userId}/unread")
+    @Operation(summary = "Get unread notifications", description = "Retrieve all unread notifications for a user")
+    public ResponseEntity<List<NotificationResponse>> getUnreadNotifications(
+            @Parameter(description = "User ID") @PathVariable Long userId) {
+
+        List<NotificationResponse> response = notificationService.getUnreadNotifications(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/user/{userId}/count")
+    @Operation(summary = "Get unread count", description = "Get the count of unread notifications for a user")
+    public ResponseEntity<Map<String, Object>> getUnreadNotificationCount(
+            @Parameter(description = "User ID") @PathVariable Long userId) {
+
+        long unreadCount = notificationService.getUnreadNotificationCount(userId);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("unreadCount", unreadCount);
+        response.put("hasUnread", unreadCount > 0);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{notificationId}/read")
+    @Operation(summary = "Mark notification as read", description = "Mark a specific notification as read")
+    public ResponseEntity<Map<String, Object>> markNotificationAsRead(
+            @Parameter(description = "Notification ID") @PathVariable Long notificationId,
+            @Parameter(description = "User ID") @RequestParam Long userId) {
+
+        notificationService.markNotificationAsRead(notificationId, userId);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("success", true);
+        response.put("message", "Notification marked as read");
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/user/{userId}/read-all")
+    @Operation(summary = "Mark all notifications as read", description = "Mark all notifications as read for a user")
+    public ResponseEntity<Map<String, Object>> markAllNotificationsAsRead(
+            @Parameter(description = "User ID") @PathVariable Long userId) {
+
+        notificationService.markAllNotificationsAsRead(userId);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("success", true);
+        response.put("message", "All notifications marked as read");
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Controller/QuestionController.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Controller/QuestionController.java
@@ -1,0 +1,144 @@
+package com.stackit.chat_manage_service.Controller;
+
+import com.stackit.chat_manage_service.Payload.Request.CreateQuestionRequest;
+import com.stackit.chat_manage_service.Payload.Response.QuestionResponse;
+import com.stackit.chat_manage_service.Service.QuestionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/questions")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Questions", description = "Question management operations")
+public class QuestionController {
+
+    private final QuestionService questionService;
+
+    @PostMapping
+    @Operation(summary = "Create a new question", description = "Create a new question with title, description, and tags")
+    public ResponseEntity<QuestionResponse> createQuestion(
+            @Valid @RequestBody CreateQuestionRequest request) {
+
+        log.info("Creating question: {}", request.getTitle());
+        QuestionResponse response = questionService.createQuestion(request);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Get question by ID", description = "Retrieve a specific question with its details and answers")
+    public ResponseEntity<QuestionResponse> getQuestion(
+            @Parameter(description = "Question ID") @PathVariable Long id,
+            @Parameter(description = "Current user ID for personalization") @RequestParam(required = false) Long currentUserId) {
+
+        QuestionResponse response = questionService.getQuestionById(id, currentUserId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    @Operation(summary = "Get all questions", description = "Retrieve paginated list of all active questions")
+    public ResponseEntity<Page<QuestionResponse>> getAllQuestions(
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size,
+            @Parameter(description = "Sort by field") @RequestParam(defaultValue = "createdAt") String sortBy,
+            @Parameter(description = "Sort direction") @RequestParam(defaultValue = "desc") String sortDir) {
+
+        Sort.Direction direction = sortDir.equalsIgnoreCase("desc") ? Sort.Direction.DESC : Sort.Direction.ASC;
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
+
+        Page<QuestionResponse> response = questionService.getAllQuestions(pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "Search questions", description = "Search questions by keyword in title or description")
+    public ResponseEntity<Page<QuestionResponse>> searchQuestions(
+            @Parameter(description = "Search keyword") @RequestParam String q,
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<QuestionResponse> response = questionService.searchQuestions(q, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/tagged")
+    @Operation(summary = "Get questions by tags", description = "Retrieve questions filtered by specific tags")
+    public ResponseEntity<Page<QuestionResponse>> getQuestionsByTags(
+            @Parameter(description = "Tag names") @RequestParam List<String> tags,
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<QuestionResponse> response = questionService.getQuestionsByTags(tags, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/unanswered")
+    @Operation(summary = "Get unanswered questions", description = "Retrieve questions that don't have accepted answers")
+    public ResponseEntity<Page<QuestionResponse>> getUnansweredQuestions(
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<QuestionResponse> response = questionService.getUnansweredQuestions(pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/recent")
+    @Operation(summary = "Get recent questions", description = "Retrieve questions from the last N days")
+    public ResponseEntity<Page<QuestionResponse>> getRecentQuestions(
+            @Parameter(description = "Number of days") @RequestParam(defaultValue = "7") int days,
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<QuestionResponse> response = questionService.getRecentQuestions(days, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Update question", description = "Update an existing question (only by question owner)")
+    public ResponseEntity<QuestionResponse> updateQuestion(
+            @Parameter(description = "Question ID") @PathVariable Long id,
+            @Valid @RequestBody CreateQuestionRequest request,
+            @Parameter(description = "Current user ID") @RequestParam Long currentUserId) {
+
+        QuestionResponse response = questionService.updateQuestion(id, request, currentUserId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{id}/accept-answer/{answerId}")
+    @Operation(summary = "Accept answer", description = "Mark an answer as accepted for the question")
+    public ResponseEntity<Void> acceptAnswer(
+            @Parameter(description = "Question ID") @PathVariable Long id,
+            @Parameter(description = "Answer ID") @PathVariable Long answerId,
+            @Parameter(description = "Current user ID") @RequestParam Long currentUserId) {
+
+        questionService.acceptAnswer(id, answerId, currentUserId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Delete question", description = "Soft delete a question (only by question owner)")
+    public ResponseEntity<Void> deleteQuestion(
+            @Parameter(description = "Question ID") @PathVariable Long id,
+            @Parameter(description = "Current user ID") @RequestParam Long currentUserId) {
+
+        questionService.deleteQuestion(id, currentUserId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Controller/TagController.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Controller/TagController.java
@@ -1,0 +1,78 @@
+package com.stackit.chat_manage_service.Controller;
+
+import com.stackit.chat_manage_service.Payload.Response.TagResponse;
+import com.stackit.chat_manage_service.Service.TagService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/tags")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Tags", description = "Tag management operations")
+public class TagController {
+
+    private final TagService tagService;
+
+    @GetMapping
+    @Operation(summary = "Get all tags", description = "Retrieve paginated list of all active tags")
+    public ResponseEntity<Page<TagResponse>> getAllTags(
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size,
+            @Parameter(description = "Sort by field") @RequestParam(defaultValue = "usageCount") String sortBy,
+            @Parameter(description = "Sort direction") @RequestParam(defaultValue = "desc") String sortDir) {
+
+        Sort.Direction direction = sortDir.equalsIgnoreCase("desc") ? Sort.Direction.DESC : Sort.Direction.ASC;
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
+
+        Page<TagResponse> response = tagService.getAllTags(pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "Search tags", description = "Search tags by keyword")
+    public ResponseEntity<List<TagResponse>> searchTags(
+            @Parameter(description = "Search keyword") @RequestParam(required = false) String q) {
+
+        List<TagResponse> response = tagService.searchTags(q);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/popular")
+    @Operation(summary = "Get popular tags", description = "Get most used tags")
+    public ResponseEntity<List<TagResponse>> getPopularTags(
+            @Parameter(description = "Number of tags to return") @RequestParam(defaultValue = "10") int limit) {
+
+        List<TagResponse> response = tagService.getMostUsedTags(limit);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Get tag by ID", description = "Retrieve a specific tag by its ID")
+    public ResponseEntity<TagResponse> getTagById(
+            @Parameter(description = "Tag ID") @PathVariable Long id) {
+
+        TagResponse response = tagService.getTagById(id);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/name/{name}")
+    @Operation(summary = "Get tag by name", description = "Retrieve a specific tag by its name")
+    public ResponseEntity<TagResponse> getTagByName(
+            @Parameter(description = "Tag name") @PathVariable String name) {
+
+        TagResponse response = tagService.getTagByName(name);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Controller/VoteController.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Controller/VoteController.java
@@ -1,0 +1,94 @@
+package com.stackit.chat_manage_service.Controller;
+
+import com.stackit.chat_manage_service.Entity.enums.VoteType;
+import com.stackit.chat_manage_service.Payload.Request.VoteRequest;
+import com.stackit.chat_manage_service.Service.VoteService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/votes")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Votes", description = "Voting operations on answers")
+public class VoteController {
+
+    private final VoteService voteService;
+
+    @PostMapping("/answers/{answerId}")
+    @Operation(summary = "Vote on answer", description = "Upvote or downvote an answer")
+    public ResponseEntity<Map<String, Object>> voteOnAnswer(
+            @Parameter(description = "Answer ID") @PathVariable Long answerId,
+            @Valid @RequestBody VoteRequest request) {
+
+        log.info("Processing vote on answer: {} by user: {}", answerId, request.getUserId());
+        voteService.voteOnAnswer(answerId, request);
+
+        // Return updated vote statistics
+        Map<String, Object> response = new HashMap<>();
+        response.put("success", true);
+        response.put("message", "Vote processed successfully");
+        response.put("score", voteService.getAnswerScore(answerId));
+        response.put("upvotes", voteService.getUpvoteCount(answerId));
+        response.put("downvotes", voteService.getDownvoteCount(answerId));
+
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/answers/{answerId}")
+    @Operation(summary = "Remove vote", description = "Remove user's vote from an answer")
+    public ResponseEntity<Map<String, Object>> removeVote(
+            @Parameter(description = "Answer ID") @PathVariable Long answerId,
+            @Parameter(description = "User ID") @RequestParam Long userId) {
+
+        log.info("Removing vote on answer: {} by user: {}", answerId, userId);
+        voteService.removeVote(answerId, userId);
+
+        // Return updated vote statistics
+        Map<String, Object> response = new HashMap<>();
+        response.put("success", true);
+        response.put("message", "Vote removed successfully");
+        response.put("score", voteService.getAnswerScore(answerId));
+        response.put("upvotes", voteService.getUpvoteCount(answerId));
+        response.put("downvotes", voteService.getDownvoteCount(answerId));
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/answers/{answerId}/score")
+    @Operation(summary = "Get answer score", description = "Get the current vote score for an answer")
+    public ResponseEntity<Map<String, Object>> getAnswerScore(
+            @Parameter(description = "Answer ID") @PathVariable Long answerId) {
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("score", voteService.getAnswerScore(answerId));
+        response.put("upvotes", voteService.getUpvoteCount(answerId));
+        response.put("downvotes", voteService.getDownvoteCount(answerId));
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/answers/{answerId}/user/{userId}")
+    @Operation(summary = "Get user vote", description = "Get user's current vote on an answer")
+    public ResponseEntity<Map<String, Object>> getUserVote(
+            @Parameter(description = "Answer ID") @PathVariable Long answerId,
+            @Parameter(description = "User ID") @PathVariable Long userId) {
+
+        VoteType userVote = voteService.getUserVoteForAnswer(answerId, userId);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("voteType", userVote != null ? userVote.name() : null);
+        response.put("hasVoted", userVote != null);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Controller/WebSocketController.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Controller/WebSocketController.java
@@ -1,0 +1,63 @@
+package com.stackit.chat_manage_service.Controller;
+
+import com.stackit.chat_manage_service.Service.WebSocketService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.stereotype.Controller;
+
+import java.util.Map;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketController {
+
+    private final WebSocketService webSocketService;
+
+    @MessageMapping("/question/{questionId}/typing")
+    public void handleTypingIndicator(
+            @DestinationVariable Long questionId,
+            @Payload Map<String, Object> message) {
+
+        try {
+            String username = (String) message.get("username");
+            Boolean isTyping = (Boolean) message.get("isTyping");
+
+            if (username != null && isTyping != null) {
+                webSocketService.broadcastTypingIndicator(questionId, username, isTyping);
+            }
+        } catch (Exception e) {
+            log.error("Error handling typing indicator: {}", e.getMessage());
+        }
+    }
+
+    @MessageMapping("/user/status")
+    public void handleUserStatusUpdate(@Payload Map<String, Object> message) {
+        try {
+            Number userIdNumber = (Number) message.get("userId");
+            Boolean isOnline = (Boolean) message.get("isOnline");
+
+            if (userIdNumber != null && isOnline != null) {
+                Long userId = userIdNumber.longValue();
+                webSocketService.broadcastUserOnlineStatus(userId, isOnline);
+            }
+        } catch (Exception e) {
+            log.error("Error handling user status update: {}", e.getMessage());
+        }
+    }
+
+    @MessageMapping("/ping")
+    @SendToUser("/queue/pong")
+    public Map<String, Object> handlePing(@Payload Map<String, Object> message) {
+        // Simple ping-pong for connection health check
+        return Map.of(
+                "type", "PONG",
+                "timestamp", System.currentTimeMillis(),
+                "originalMessage", message
+        );
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/Answer.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/Answer.java
@@ -1,0 +1,71 @@
+package com.stackit.chat_manage_service.Entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "answers")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Answer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Builder.Default
+    @Column(name = "is_accepted", nullable = false)
+    private Boolean isAccepted = false;
+
+    @Builder.Default
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
+    @Column(name = "edited_at")
+    private LocalDateTime editedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    // Relationships
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    private Question question;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToMany(mappedBy = "answer", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Vote> votes;
+
+    // Derived fields
+    @Transient
+    private Integer score;
+
+    @Transient
+    private Integer upvoteCount;
+
+    @Transient
+    private Integer downvoteCount;
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/Message.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/Message.java
@@ -1,0 +1,26 @@
+package com.stackit.chat_manage_service.Entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class Message {
+
+    private String id;
+    private String sender;
+    private String content;
+    private LocalDateTime timeStamp;
+
+    public Message(String sender, String content) {
+        this.sender = sender;
+        this.content = content;
+        this.timeStamp = LocalDateTime.now();
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/Notification.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/Notification.java
@@ -1,0 +1,62 @@
+package com.stackit.chat_manage_service.Entity;
+
+import com.stackit.chat_manage_service.Entity.enums.NotificationType;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notifications")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "notification_type", nullable = false)
+    private NotificationType type;
+
+    @Column(nullable = false, length = 500)
+    private String message;
+
+    @Column(name = "reference_id")
+    private Long referenceId;
+
+    @Column(name = "reference_type", length = 50)
+    private String referenceType;
+
+    @Builder.Default
+    @Column(name = "is_read", nullable = false)
+    private Boolean isRead = false;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    @Column(name = "action_url")
+    private String actionUrl;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // Relationships
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "triggered_by_user_id")
+    private User triggeredByUser;
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/Question.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/Question.java
@@ -1,0 +1,86 @@
+package com.stackit.chat_manage_service.Entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+@Entity
+@Table(name = "questions")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Question {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Builder.Default
+    @Column(name = "view_count", nullable = false)
+    private Integer viewCount = 0;
+
+    @Builder.Default
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
+    @Builder.Default
+    @Column(name = "is_closed", nullable = false)
+    private Boolean isClosed = false;
+
+    @Column(name = "close_reason")
+    private String closeReason;
+
+    @Column(name = "accepted_answer_id")
+    private Long acceptedAnswerId;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    // Relationships
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Answer> answers;
+
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+            name = "question_tags",
+            joinColumns = @JoinColumn(name = "question_id"),
+            inverseJoinColumns = @JoinColumn(name = "tag_id")
+    )
+    private Set<Tag> tags;
+
+    // Derived fields
+    @Transient
+    private Integer answerCount;
+
+    @Transient
+    private Integer score;
+
+    @Transient
+    private Boolean hasAcceptedAnswer;
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/Tag.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/Tag.java
@@ -1,0 +1,51 @@
+package com.stackit.chat_manage_service.Entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Entity
+@Table(name = "tags")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false, length = 50)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Builder.Default
+    @Column(name = "usage_count", nullable = false)
+    private Integer usageCount = 0;
+
+    @Builder.Default
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
+    @Column(name = "color_code", length = 7)
+    private String colorCode;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // Relationships
+    @ManyToMany(mappedBy = "tags", fetch = FetchType.LAZY)
+    private Set<Question> questions;
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/User.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/User.java
@@ -1,0 +1,81 @@
+package com.stackit.chat_manage_service.Entity;
+
+import com.stackit.chat_manage_service.Entity.enums.UserRole;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "users")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false, length = 50)
+    private String username;
+
+    @Column(unique = true, nullable = false, length = 100)
+    private String email;
+
+    @Column(name = "display_name", length = 100)
+    private String displayName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private UserRole role = UserRole.USER;
+
+    @Builder.Default
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
+    @Builder.Default
+    @Column(name = "is_banned", nullable = false)
+    private Boolean isBanned = false;
+
+    @Column(name = "avatar_url")
+    private String avatarUrl;
+
+    @Column(columnDefinition = "TEXT")
+    private String bio;
+
+    @Builder.Default
+    @Column(name = "reputation_score", nullable = false)
+    private Integer reputationScore = 0;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    // Relationships
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Question> questions;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Answer> answers;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Vote> votes;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Notification> notifications;
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/Vote.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/Vote.java
@@ -1,0 +1,45 @@
+package com.stackit.chat_manage_service.Entity;
+
+import com.stackit.chat_manage_service.Entity.enums.VoteType;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "votes", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "answer_id"})
+})
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Vote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "vote_type", nullable = false)
+    private VoteType voteType;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // Relationships
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "answer_id", nullable = false)
+    private Answer answer;
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/enums/NotificationType.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/enums/NotificationType.java
@@ -1,0 +1,22 @@
+package com.stackit.chat_manage_service.Entity.enums;
+
+public enum NotificationType {
+    QUESTION_ANSWERED("Someone answered your question"),
+    ANSWER_COMMENTED("Someone commented on your answer"),
+    USER_MENTIONED("You were mentioned in a post"),
+    ANSWER_ACCEPTED("Your answer was accepted"),
+    QUESTION_UPVOTED("Your question was upvoted"),
+    ANSWER_UPVOTED("Your answer was upvoted"),
+    QUESTION_DOWNVOTED("Your question was downvoted"),
+    ANSWER_DOWNVOTED("Your answer was downvoted");
+
+    private final String defaultMessage;
+
+    NotificationType(String defaultMessage) {
+        this.defaultMessage = defaultMessage;
+    }
+
+    public String getDefaultMessage() {
+        return defaultMessage;
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/enums/UserRole.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/enums/UserRole.java
@@ -1,0 +1,16 @@
+package com.stackit.chat_manage_service.Entity.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum UserRole {
+    GUEST("Guest"),
+    USER("User"),
+    ADMIN("Admin");
+
+    private final String displayName;
+
+    UserRole(String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/enums/VoteType.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Entity/enums/VoteType.java
@@ -1,0 +1,16 @@
+package com.stackit.chat_manage_service.Entity.enums;
+
+public enum VoteType {
+    UPVOTE(1),
+    DOWNVOTE(-1);
+
+    private final int value;
+
+    VoteType(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Exception/GlobalExceptionHandler.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Exception/GlobalExceptionHandler.java
@@ -1,0 +1,123 @@
+package com.stackit.chat_manage_service.Exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<Map<String, Object>> handleRuntimeException(RuntimeException ex) {
+        log.error("Runtime exception occurred: {}", ex.getMessage(), ex);
+
+        Map<String, Object> errorResponse = createErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "Bad Request",
+                ex.getMessage()
+        );
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationException(MethodArgumentNotValidException ex) {
+        log.error("Validation exception occurred: {}", ex.getMessage());
+
+        Map<String, String> fieldErrors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach(error -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            fieldErrors.put(fieldName, errorMessage);
+        });
+
+        Map<String, Object> errorResponse = createErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "Validation Failed",
+                "Invalid input data"
+        );
+        errorResponse.put("fieldErrors", fieldErrors);
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Map<String, Object>> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
+        log.error("Data integrity violation: {}", ex.getMessage(), ex);
+
+        String message = "Data integrity violation occurred";
+        if (ex.getMessage().contains("duplicate key")) {
+            message = "A record with this data already exists";
+        } else if (ex.getMessage().contains("foreign key")) {
+            message = "Referenced data does not exist";
+        }
+
+        Map<String, Object> errorResponse = createErrorResponse(
+                HttpStatus.CONFLICT.value(),
+                "Data Conflict",
+                message
+        );
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<Map<String, Object>> handleMaxUploadSizeException(MaxUploadSizeExceededException ex) {
+        log.error("File upload size exceeded: {}", ex.getMessage());
+
+        Map<String, Object> errorResponse = createErrorResponse(
+                HttpStatus.PAYLOAD_TOO_LARGE.value(),
+                "File Too Large",
+                "The uploaded file exceeds the maximum allowed size"
+        );
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.PAYLOAD_TOO_LARGE);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, Object>> handleIllegalArgumentException(IllegalArgumentException ex) {
+        log.error("Illegal argument exception: {}", ex.getMessage(), ex);
+
+        Map<String, Object> errorResponse = createErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "Invalid Argument",
+                ex.getMessage()
+        );
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleGenericException(Exception ex) {
+        log.error("Unexpected exception occurred: {}", ex.getMessage(), ex);
+
+        Map<String, Object> errorResponse = createErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "Internal Server Error",
+                "An unexpected error occurred. Please try again later."
+        );
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private Map<String, Object> createErrorResponse(int status, String error, String message) {
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("timestamp", LocalDateTime.now());
+        errorResponse.put("status", status);
+        errorResponse.put("error", error);
+        errorResponse.put("message", message);
+        errorResponse.put("success", false);
+        return errorResponse;
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Payload/Request/CreateAnswerRequest.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Payload/Request/CreateAnswerRequest.java
@@ -1,0 +1,22 @@
+package com.stackit.chat_manage_service.Payload.Request;
+
+import jakarta.validation.constraints.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateAnswerRequest {
+
+    @NotBlank(message = "Content is required")
+    @Size(min = 30, max = 50000, message = "Content must be between 30 and 50000 characters")
+    private String content;
+
+    @NotNull(message = "Question ID is required")
+    private Long questionId;
+
+    @NotNull(message = "User ID is required")
+    private Long userId;
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Payload/Request/CreateQuestionRequest.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Payload/Request/CreateQuestionRequest.java
@@ -1,0 +1,29 @@
+package com.stackit.chat_manage_service.Payload.Request;
+
+import jakarta.validation.constraints.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.util.Set;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateQuestionRequest {
+
+    @NotBlank(message = "Title is required")
+    @Size(min = 10, max = 200, message = "Title must be between 10 and 200 characters")
+    private String title;
+
+    @NotBlank(message = "Description is required")
+    @Size(min = 30, max = 50000, message = "Description must be between 30 and 50000 characters")
+    private String description;
+
+    @NotNull(message = "Tags are required")
+    @Size(min = 1, max = 5, message = "Must have between 1 and 5 tags")
+    private Set<String> tags;
+
+    @NotNull(message = "User ID is required")
+    private Long userId;
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Payload/Request/VoteRequest.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Payload/Request/VoteRequest.java
@@ -1,0 +1,19 @@
+package com.stackit.chat_manage_service.Payload.Request;
+
+import com.stackit.chat_manage_service.Entity.enums.VoteType;
+import jakarta.validation.constraints.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class VoteRequest {
+
+    @NotNull(message = "Vote type is required")
+    private VoteType voteType;
+
+    @NotNull(message = "User ID is required")
+    private Long userId;
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Payload/Response/AnswerResponse.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Payload/Response/AnswerResponse.java
@@ -1,0 +1,34 @@
+package com.stackit.chat_manage_service.Payload.Response;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AnswerResponse {
+
+    private Long id;
+    private String content;
+    private Boolean isAccepted;
+    private Boolean isActive;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime editedAt;
+
+    private UserSummaryResponse user;
+    private Long questionId;
+
+    // Derived fields
+    private Integer score;
+    private Integer upvoteCount;
+    private Integer downvoteCount;
+
+    // Current user's vote (if any)
+    private String currentUserVote; // UPVOTE, DOWNVOTE, or null
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Payload/Response/NotificationResponse.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Payload/Response/NotificationResponse.java
@@ -1,0 +1,28 @@
+package com.stackit.chat_manage_service.Payload.Response;
+
+import com.stackit.chat_manage_service.Entity.enums.NotificationType;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationResponse {
+
+    private Long id;
+    private NotificationType type;
+    private String message;
+    private Long referenceId;
+    private String referenceType;
+    private Boolean isRead;
+    private LocalDateTime readAt;
+    private String actionUrl;
+    private LocalDateTime createdAt;
+
+    private UserSummaryResponse triggeredByUser;
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Payload/Response/QuestionResponse.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Payload/Response/QuestionResponse.java
@@ -1,0 +1,39 @@
+package com.stackit.chat_manage_service.Payload.Response;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuestionResponse {
+
+    private Long id;
+    private String title;
+    private String description;
+    private Integer viewCount;
+    private Boolean isActive;
+    private Boolean isClosed;
+    private String closeReason;
+    private Long acceptedAnswerId;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    private UserSummaryResponse user;
+    private Set<TagResponse> tags;
+
+    // Derived fields
+    private Integer answerCount;
+    private Integer score;
+    private Boolean hasAcceptedAnswer;
+
+    // Optional fields for detailed view
+    private List<AnswerResponse> answers;
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Payload/Response/TagResponse.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Payload/Response/TagResponse.java
@@ -1,0 +1,23 @@
+package com.stackit.chat_manage_service.Payload.Response;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TagResponse {
+
+    private Long id;
+    private String name;
+    private String description;
+    private Integer usageCount;
+    private Boolean isActive;
+    private String colorCode;
+    private LocalDateTime createdAt;
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Payload/Response/UserSummaryResponse.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Payload/Response/UserSummaryResponse.java
@@ -1,0 +1,28 @@
+package com.stackit.chat_manage_service.Payload.Response;
+
+import com.stackit.chat_manage_service.Entity.enums.UserRole;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserSummaryResponse {
+
+    private Long id;
+    private String username;
+    private String displayName;
+    private UserRole role;
+    private String avatarUrl;
+    private Integer reputationScore;
+    private LocalDateTime createdAt;
+
+    // Statistics
+    private Long questionCount;
+    private Long answerCount;
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Repository/AnswerRepository.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Repository/AnswerRepository.java
@@ -1,0 +1,68 @@
+package com.stackit.chat_manage_service.Repository;
+
+import com.stackit.chat_manage_service.Entity.Answer;
+import com.stackit.chat_manage_service.Entity.Question;
+import com.stackit.chat_manage_service.Entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+    List<Answer> findByQuestionAndIsActiveTrueOrderByCreatedAtAsc(Question question);
+
+    Page<Answer> findByQuestionAndIsActiveTrueOrderByCreatedAtAsc(Question question, Pageable pageable);
+
+    Page<Answer> findByUser(User user, Pageable pageable);
+
+    Optional<Answer> findByIdAndIsActiveTrue(Long id);
+
+    @Query("SELECT a FROM Answer a WHERE a.question = :question AND a.isActive = true " +
+            "ORDER BY a.isAccepted DESC, " +
+            "(SELECT COUNT(v) FROM Vote v WHERE v.answer = a AND v.voteType = 'UPVOTE') , " +
+            "(SELECT COUNT(v) FROM Vote v WHERE v.answer = a AND v.voteType = 'DOWNVOTE') DESC, " +
+            "a.createdAt ASC")
+    List<Answer> findByQuestionOrderedByScoreAndAcceptance(@Param("question") Question question);
+
+    @Query("SELECT a FROM Answer a WHERE a.isActive = true AND a.isAccepted = true")
+    Page<Answer> findAcceptedAnswers(Pageable pageable);
+
+    @Query("SELECT a FROM Answer a WHERE a.isActive = true AND " +
+            "LOWER(a.content) LIKE LOWER(CONCAT('%', :keyword, '%'))")
+    Page<Answer> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    @Query("SELECT a FROM Answer a WHERE a.isActive = true AND a.createdAt >= :since")
+    Page<Answer> findRecentAnswers(@Param("since") LocalDateTime since, Pageable pageable);
+
+    @Query("SELECT a FROM Answer a LEFT JOIN a.votes v WHERE a.isActive = true " +
+            "GROUP BY a.id ORDER BY " +
+            "SUM(CASE WHEN v.voteType = 'UPVOTE' THEN 1 ELSE 0 END) - " +
+            "SUM(CASE WHEN v.voteType = 'DOWNVOTE' THEN 1 ELSE 0 END) DESC")
+    Page<Answer> findMostUpvotedAnswers(Pageable pageable);
+
+    @Modifying
+    @Query("UPDATE Answer a SET a.isAccepted = true WHERE a.id = :answerId")
+    void acceptAnswer(@Param("answerId") Long answerId);
+
+    @Modifying
+    @Query("UPDATE Answer a SET a.isAccepted = false WHERE a.question = :question")
+    void unacceptAllAnswersForQuestion(@Param("question") Question question);
+
+    @Query("SELECT COUNT(a) FROM Answer a WHERE a.question = :question AND a.isActive = true")
+    long countByQuestion(@Param("question") Question question);
+
+    @Query("SELECT COUNT(a) FROM Answer a WHERE a.user = :user AND a.isActive = true")
+    long countByUser(@Param("user") User user);
+
+    @Query("SELECT COUNT(a) FROM Answer a WHERE a.isActive = true AND a.createdAt >= :since")
+    long countRecentAnswers(@Param("since") LocalDateTime since);
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Repository/NotificationRepository.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Repository/NotificationRepository.java
@@ -1,0 +1,49 @@
+package com.stackit.chat_manage_service.Repository;
+
+import com.stackit.chat_manage_service.Entity.Notification;
+import com.stackit.chat_manage_service.Entity.User;
+import com.stackit.chat_manage_service.Entity.enums.NotificationType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    Page<Notification> findByUserOrderByCreatedAtDesc(User user, Pageable pageable);
+
+    List<Notification> findByUserAndIsReadFalseOrderByCreatedAtDesc(User user);
+
+    Page<Notification> findByUserAndIsReadFalseOrderByCreatedAtDesc(User user, Pageable pageable);
+
+    List<Notification> findByUserAndTypeOrderByCreatedAtDesc(User user, NotificationType type);
+
+    @Query("SELECT COUNT(n) FROM Notification n WHERE n.user = :user AND n.isRead = false")
+    long countUnreadByUser(@Param("user") User user);
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = true, n.readAt = :readAt WHERE n.id = :notificationId")
+    void markAsRead(@Param("notificationId") Long notificationId, @Param("readAt") LocalDateTime readAt);
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = true, n.readAt = :readAt WHERE n.user = :user AND n.isRead = false")
+    void markAllAsReadForUser(@Param("user") User user, @Param("readAt") LocalDateTime readAt);
+
+    @Modifying
+    @Query("DELETE FROM Notification n WHERE n.createdAt < :cutoffDate")
+    void deleteOldNotifications(@Param("cutoffDate") LocalDateTime cutoffDate);
+
+    @Query("SELECT n FROM Notification n WHERE n.user = :user AND n.referenceId = :referenceId AND n.type = :type")
+    List<Notification> findByUserAndReferenceIdAndType(@Param("user") User user,
+                                                       @Param("referenceId") Long referenceId,
+                                                       @Param("type") NotificationType type);
+
+    boolean existsByUserAndReferenceIdAndType(User user, Long referenceId, NotificationType type);
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Repository/QuestionRepository.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Repository/QuestionRepository.java
@@ -1,0 +1,67 @@
+package com.stackit.chat_manage_service.Repository;
+
+import com.stackit.chat_manage_service.Entity.Question;
+import com.stackit.chat_manage_service.Entity.Tag;
+import com.stackit.chat_manage_service.Entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    @Query("SELECT DISTINCT q FROM Question q LEFT JOIN FETCH q.tags LEFT JOIN FETCH q.user WHERE q.isActive = true ORDER BY q.createdAt DESC")
+    Page<Question> findByIsActiveTrueOrderByCreatedAtDesc(Pageable pageable);
+
+    Page<Question> findByIsActiveTrueAndIsClosedFalseOrderByCreatedAtDesc(Pageable pageable);
+
+    Page<Question> findByUser(User user, Pageable pageable);
+
+    Page<Question> findByTitleContainingIgnoreCaseAndIsActiveTrue(String title, Pageable pageable);
+
+    @Query("SELECT q FROM Question q WHERE q.isActive = true AND " +
+            "(LOWER(q.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
+            "LOWER(q.description) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+    Page<Question> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    @Query("SELECT q FROM Question q JOIN q.tags t WHERE t IN :tags AND q.isActive = true")
+    Page<Question> findByTags(@Param("tags") List<Tag> tags, Pageable pageable);
+
+    @Query("SELECT q FROM Question q WHERE q.isActive = true AND q.acceptedAnswerId IS NOT NULL")
+    Page<Question> findAnsweredQuestions(Pageable pageable);
+
+    @Query("SELECT q FROM Question q WHERE q.isActive = true AND q.acceptedAnswerId IS NULL")
+    Page<Question> findUnansweredQuestions(Pageable pageable);
+
+    @Query("SELECT q FROM Question q WHERE q.isActive = true ORDER BY q.viewCount DESC")
+    Page<Question> findMostViewedQuestions(Pageable pageable);
+
+    @Query("SELECT q FROM Question q LEFT JOIN q.answers a WHERE q.isActive = true " +
+            "GROUP BY q.id ORDER BY COUNT(a) DESC")
+    Page<Question> findMostAnsweredQuestions(Pageable pageable);
+
+    @Query("SELECT q FROM Question q WHERE q.isActive = true AND q.createdAt >= :since")
+    Page<Question> findRecentQuestions(@Param("since") LocalDateTime since, Pageable pageable);
+
+    @Modifying
+    @Query("UPDATE Question q SET q.viewCount = q.viewCount + 1 WHERE q.id = :questionId")
+    void incrementViewCount(@Param("questionId") Long questionId);
+
+    @Modifying
+    @Query("UPDATE Question q SET q.acceptedAnswerId = :answerId WHERE q.id = :questionId")
+    void updateAcceptedAnswer(@Param("questionId") Long questionId, @Param("answerId") Long answerId);
+
+    @Query("SELECT COUNT(q) FROM Question q WHERE q.user = :user AND q.isActive = true")
+    long countByUser(@Param("user") User user);
+
+    @Query("SELECT COUNT(q) FROM Question q WHERE q.isActive = true AND q.createdAt >= :since")
+    long countRecentQuestions(@Param("since") LocalDateTime since);
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Repository/TagRepository.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Repository/TagRepository.java
@@ -1,0 +1,48 @@
+package com.stackit.chat_manage_service.Repository;
+
+import com.stackit.chat_manage_service.Entity.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    Optional<Tag> findByName(String name);
+
+    List<Tag> findByNameContainingIgnoreCase(String name);
+
+    Page<Tag> findByIsActiveTrueOrderByUsageCountDesc(Pageable pageable);
+
+    Page<Tag> findByIsActiveTrueOrderByNameAsc(Pageable pageable);
+
+    @Query("SELECT t FROM Tag t WHERE t.isActive = true AND " +
+            "LOWER(t.name) LIKE LOWER(CONCAT('%', :keyword, '%'))")
+    List<Tag> findByKeyword(@Param("keyword") String keyword);
+
+    @Query("SELECT t FROM Tag t WHERE t.isActive = true ORDER BY t.usageCount DESC")
+    List<Tag> findMostUsedTags(Pageable pageable);
+
+    @Query("SELECT t FROM Tag t WHERE t.isActive = true AND t.usageCount > 0 ORDER BY t.usageCount DESC")
+    List<Tag> findActiveTags();
+
+    @Modifying
+    @Query("UPDATE Tag t SET t.usageCount = t.usageCount + 1 WHERE t.id = :tagId")
+    void incrementUsageCount(@Param("tagId") Long tagId);
+
+    @Modifying
+    @Query("UPDATE Tag t SET t.usageCount = t.usageCount - 1 WHERE t.id = :tagId AND t.usageCount > 0")
+    void decrementUsageCount(@Param("tagId") Long tagId);
+
+    @Query("SELECT COUNT(t) FROM Tag t WHERE t.isActive = true")
+    long countActiveTags();
+
+    boolean existsByName(String name);
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Repository/UserRepository.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Repository/UserRepository.java
@@ -1,0 +1,42 @@
+package com.stackit.chat_manage_service.Repository;
+
+import com.stackit.chat_manage_service.Entity.User;
+import com.stackit.chat_manage_service.Entity.enums.UserRole;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+
+    Optional<User> findByEmail(String email);
+
+    List<User> findByUsernameContainingIgnoreCase(String username);
+
+    Page<User> findByRole(UserRole role, Pageable pageable);
+
+    Page<User> findByIsActiveTrue(Pageable pageable);
+
+    Page<User> findByIsBannedTrue(Pageable pageable);
+
+    @Query("SELECT u FROM User u WHERE u.isActive = true AND u.isBanned = false ORDER BY u.reputationScore DESC")
+    Page<User> findTopUsers(Pageable pageable);
+
+    @Query("SELECT COUNT(u) FROM User u WHERE u.role = :role")
+    long countByRole(@Param("role") UserRole role);
+
+    @Query("SELECT COUNT(u) FROM User u WHERE u.isActive = true AND u.isBanned = false")
+    long countActiveUsers();
+
+    boolean existsByUsername(String username);
+
+    boolean existsByEmail(String email);
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Repository/VoteRepository.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Repository/VoteRepository.java
@@ -1,0 +1,46 @@
+package com.stackit.chat_manage_service.Repository;
+
+import com.stackit.chat_manage_service.Entity.Answer;
+import com.stackit.chat_manage_service.Entity.User;
+import com.stackit.chat_manage_service.Entity.Vote;
+import com.stackit.chat_manage_service.Entity.enums.VoteType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+
+    Optional<Vote> findByUserAndAnswer(User user, Answer answer);
+
+    List<Vote> findByAnswer(Answer answer);
+
+    List<Vote> findByUser(User user);
+
+    @Query("SELECT COUNT(v) FROM Vote v WHERE v.answer = :answer AND v.voteType = :voteType")
+    long countByAnswerAndVoteType(@Param("answer") Answer answer, @Param("voteType") VoteType voteType);
+
+    @Query("SELECT COUNT(v) FROM Vote v WHERE v.answer = :answer AND v.voteType = 'UPVOTE'")
+    long countUpvotesByAnswer(@Param("answer") Answer answer);
+
+    @Query("SELECT COUNT(v) FROM Vote v WHERE v.answer = :answer AND v.voteType = 'DOWNVOTE'")
+    long countDownvotesByAnswer(@Param("answer") Answer answer);
+
+    @Query("SELECT " +
+            "SUM(CASE WHEN v.voteType = 'UPVOTE' THEN 1 ELSE 0 END) - " +
+            "SUM(CASE WHEN v.voteType = 'DOWNVOTE' THEN 1 ELSE 0 END) " +
+            "FROM Vote v WHERE v.answer = :answer")
+    Integer calculateScoreByAnswer(@Param("answer") Answer answer);
+
+    @Query("SELECT v FROM Vote v WHERE v.user = :user AND v.answer IN " +
+            "(SELECT a FROM Answer a WHERE a.question.id = :questionId)")
+    List<Vote> findByUserAndQuestionId(@Param("user") User user, @Param("questionId") Long questionId);
+
+    boolean existsByUserAndAnswer(User user, Answer answer);
+
+    void deleteByUserAndAnswer(User user, Answer answer);
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Service/AnswerService.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Service/AnswerService.java
@@ -1,0 +1,232 @@
+package com.stackit.chat_manage_service.Service;
+
+import com.stackit.chat_manage_service.Entity.Answer;
+import com.stackit.chat_manage_service.Entity.Question;
+import com.stackit.chat_manage_service.Entity.User;
+import com.stackit.chat_manage_service.Payload.Response.UserSummaryResponse;
+import com.stackit.chat_manage_service.Repository.AnswerRepository;
+import com.stackit.chat_manage_service.Repository.QuestionRepository;
+import com.stackit.chat_manage_service.Repository.UserRepository;
+import com.stackit.chat_manage_service.Repository.VoteRepository;
+import com.stackit.chat_manage_service.Payload.Request.CreateAnswerRequest;
+import com.stackit.chat_manage_service.Payload.Response.AnswerResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class AnswerService {
+
+    private final AnswerRepository answerRepository;
+    private final QuestionRepository questionRepository;
+    private final UserRepository userRepository;
+    private final VoteRepository voteRepository;
+    private final WebSocketService webSocketService;
+    private final NotificationService notificationService;
+
+    @Value("${app.richtext.max-length:50000}")
+    private int maxContentLength;
+
+    public AnswerResponse createAnswer(CreateAnswerRequest request) {
+        log.info("Creating answer for question: {}", request.getQuestionId());
+
+        Question question = questionRepository.findById(request.getQuestionId())
+                .orElseThrow(() -> new RuntimeException("Question not found"));
+
+        if (question.getIsClosed()) {
+            throw new RuntimeException("Cannot answer a closed question");
+        }
+
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        // Validate and sanitize content
+        String sanitizedContent = sanitizeHtmlContent(request.getContent());
+        if (sanitizedContent.length() > maxContentLength) {
+            throw new RuntimeException("Content exceeds maximum length");
+        }
+
+        Answer answer = Answer.builder()
+                .content(sanitizedContent)
+                .question(question)
+                .user(user)
+                .build();
+
+        Answer savedAnswer = answerRepository.save(answer);
+        AnswerResponse response = mapToAnswerResponse(savedAnswer, null);
+
+        // Send WebSocket notification
+        webSocketService.broadcastNewAnswer(response);
+
+        // Create notification for question owner (if not answering own question)
+        if (!question.getUser().getId().equals(user.getId())) {
+            notificationService.createQuestionAnsweredNotification(question.getId(), user.getId());
+        }
+
+        log.info("Answer created successfully with ID: {}", savedAnswer.getId());
+        return response;
+    }
+
+    @Transactional(readOnly = true)
+    public List<AnswerResponse> getAnswersByQuestion(Long questionId, Long currentUserId) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new RuntimeException("Question not found"));
+
+        List<Answer> answers = answerRepository.findByQuestionOrderedByScoreAndAcceptance(question);
+
+        return answers.stream()
+                .map(answer -> mapToAnswerResponse(answer, currentUserId))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public AnswerResponse getAnswerById(Long id, Long currentUserId) {
+        Answer answer = answerRepository.findByIdAndIsActiveTrue(id)
+                .orElseThrow(() -> new RuntimeException("Answer not found"));
+
+        return mapToAnswerResponse(answer, currentUserId);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<AnswerResponse> getAnswersByUser(Long userId, Pageable pageable) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        return answerRepository.findByUser(user, pageable)
+                .map(answer -> mapToAnswerResponse(answer, null));
+    }
+
+    public AnswerResponse updateAnswer(Long id, CreateAnswerRequest request, Long currentUserId) {
+        Answer answer = answerRepository.findByIdAndIsActiveTrue(id)
+                .orElseThrow(() -> new RuntimeException("Answer not found"));
+
+        if (!answer.getUser().getId().equals(currentUserId)) {
+            throw new RuntimeException("Not authorized to update this answer");
+        }
+
+        String sanitizedContent = sanitizeHtmlContent(request.getContent());
+        if (sanitizedContent.length() > maxContentLength) {
+            throw new RuntimeException("Content exceeds maximum length");
+        }
+
+        answer.setContent(sanitizedContent);
+        answer.setEditedAt(LocalDateTime.now());
+
+        Answer savedAnswer = answerRepository.save(answer);
+        AnswerResponse response = mapToAnswerResponse(savedAnswer, currentUserId);
+
+        // Send WebSocket notification
+        webSocketService.broadcastAnswerUpdated(response);
+
+        return response;
+    }
+
+    public void acceptAnswer(Long answerId, Long currentUserId) {
+        Answer answer = answerRepository.findByIdAndIsActiveTrue(answerId)
+                .orElseThrow(() -> new RuntimeException("Answer not found"));
+
+        Question question = answer.getQuestion();
+
+        if (!question.getUser().getId().equals(currentUserId)) {
+            throw new RuntimeException("Only question owner can accept answers");
+        }
+
+        // Unaccept all other answers for this question
+        answerRepository.unacceptAllAnswersForQuestion(question);
+
+        // Accept this answer
+        answerRepository.acceptAnswer(answerId);
+
+        // Update question's accepted answer ID
+        questionRepository.updateAcceptedAnswer(question.getId(), answerId);
+
+        // Send WebSocket notification
+        webSocketService.broadcastAnswerAccepted(question.getId(), answerId);
+
+        // Create notification for answer author
+        notificationService.createAnswerAcceptedNotification(answerId, currentUserId);
+
+        log.info("Answer {} accepted for question {}", answerId, question.getId());
+    }
+
+    public void deleteAnswer(Long id, Long currentUserId) {
+        Answer answer = answerRepository.findByIdAndIsActiveTrue(id)
+                .orElseThrow(() -> new RuntimeException("Answer not found"));
+
+        if (!answer.getUser().getId().equals(currentUserId)) {
+            throw new RuntimeException("Not authorized to delete this answer");
+        }
+
+        answer.setIsActive(false);
+        answerRepository.save(answer);
+
+        // If this was the accepted answer, remove acceptance
+        if (answer.getIsAccepted()) {
+            questionRepository.updateAcceptedAnswer(answer.getQuestion().getId(), null);
+        }
+
+        log.info("Answer deleted: {}", id);
+    }
+
+    private String sanitizeHtmlContent(String content) {
+        // This is a simplified sanitization - in production, use a proper HTML sanitizer like OWASP Java HTML Sanitizer
+        return content.trim();
+    }
+
+    private AnswerResponse mapToAnswerResponse(Answer answer, Long currentUserId) {
+        // Calculate vote counts
+        long upvoteCount = voteRepository.countUpvotesByAnswer(answer);
+        long downvoteCount = voteRepository.countDownvotesByAnswer(answer);
+        int score = (int) (upvoteCount - downvoteCount);
+
+        // Get current user's vote if provided
+        String currentUserVote = null;
+        if (currentUserId != null) {
+            User currentUser = userRepository.findById(currentUserId).orElse(null);
+            if (currentUser != null) {
+                voteRepository.findByUserAndAnswer(currentUser, answer)
+                        .ifPresent(vote -> {
+                            // Set currentUserVote to the vote type string
+                        });
+            }
+        }
+
+        return AnswerResponse.builder()
+                .id(answer.getId())
+                .content(answer.getContent())
+                .isAccepted(answer.getIsAccepted())
+                .isActive(answer.getIsActive())
+                .createdAt(answer.getCreatedAt())
+                .updatedAt(answer.getUpdatedAt())
+                .editedAt(answer.getEditedAt())
+                .user(mapToUserSummary(answer.getUser()))
+                .questionId(answer.getQuestion().getId())
+                .score(score)
+                .upvoteCount((int) upvoteCount)
+                .downvoteCount((int) downvoteCount)
+                .currentUserVote(currentUserVote)
+                .build();
+    }
+
+    private UserSummaryResponse mapToUserSummary(User user) {
+        return UserSummaryResponse.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .displayName(user.getDisplayName())
+                .role(user.getRole())
+                .avatarUrl(user.getAvatarUrl())
+                .reputationScore(user.getReputationScore())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Service/FileService.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Service/FileService.java
@@ -1,0 +1,119 @@
+package com.stackit.chat_manage_service.Service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Slf4j
+public class FileService {
+
+    @Value("${app.file.upload-dir:./uploads}")
+    private String uploadDir;
+
+    @Value("${app.file.max-size:10485760}") // 10MB in bytes
+    private long maxFileSize;
+
+    @Value("${app.file.allowed-types:image/jpeg,image/png,image/gif,image/webp}")
+    private String allowedTypes;
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd");
+
+    public String uploadFile(MultipartFile file) throws IOException {
+        validateFile(file);
+
+        // Create upload directory structure: uploads/YYYY/MM/DD/
+        String dateFolder = LocalDateTime.now().format(DATE_FORMATTER);
+        Path uploadPath = Paths.get(uploadDir, dateFolder);
+
+        if (!Files.exists(uploadPath)) {
+            Files.createDirectories(uploadPath);
+        }
+
+        // Generate unique filename
+        String originalFilename = file.getOriginalFilename();
+        String extension = originalFilename != null ?
+                originalFilename.substring(originalFilename.lastIndexOf(".")) : ".bin";
+        String uniqueFilename = UUID.randomUUID().toString() + extension;
+
+        Path filePath = uploadPath.resolve(uniqueFilename);
+
+        // Copy file to destination
+        Files.copy(file.getInputStream(), filePath, StandardCopyOption.REPLACE_EXISTING);
+
+        // Return relative path for storage in database
+        String relativePath = dateFolder + "/" + uniqueFilename;
+
+        log.info("File uploaded successfully: {} -> {}", originalFilename, relativePath);
+        return relativePath;
+    }
+
+    public byte[] getFile(String filePath) throws IOException {
+        Path path = Paths.get(uploadDir, filePath);
+
+        if (!Files.exists(path)) {
+            throw new RuntimeException("File not found: " + filePath);
+        }
+
+        return Files.readAllBytes(path);
+    }
+
+    public void deleteFile(String filePath) throws IOException {
+        Path path = Paths.get(uploadDir, filePath);
+
+        if (Files.exists(path)) {
+            Files.delete(path);
+            log.info("File deleted: {}", filePath);
+        }
+    }
+
+    public String getFileUrl(String filePath) {
+        return "/api/files/" + filePath;
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new RuntimeException("File is empty");
+        }
+
+        if (file.getSize() > maxFileSize) {
+            throw new RuntimeException("File size exceeds maximum allowed size of " +
+                    (maxFileSize / 1024 / 1024) + "MB");
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null || !isAllowedFileType(contentType)) {
+            throw new RuntimeException("File type not allowed. Allowed types: " + allowedTypes);
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || originalFilename.contains("..")) {
+            throw new RuntimeException("Invalid filename");
+        }
+    }
+
+    private boolean isAllowedFileType(String contentType) {
+        List<String> allowedTypesList = Arrays.asList(allowedTypes.split(","));
+        return allowedTypesList.contains(contentType.toLowerCase());
+    }
+
+    public long getMaxFileSize() {
+        return maxFileSize;
+    }
+
+    public List<String> getAllowedTypes() {
+        return Arrays.asList(allowedTypes.split(","));
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Service/NotificationService.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Service/NotificationService.java
@@ -1,0 +1,315 @@
+package com.stackit.chat_manage_service.Service;
+
+import com.stackit.chat_manage_service.Entity.Answer;
+import com.stackit.chat_manage_service.Entity.Notification;
+import com.stackit.chat_manage_service.Entity.Question;
+import com.stackit.chat_manage_service.Entity.User;
+import com.stackit.chat_manage_service.Entity.enums.NotificationType;
+import com.stackit.chat_manage_service.Payload.Response.NotificationResponse;
+import com.stackit.chat_manage_service.Payload.Response.UserSummaryResponse;
+import com.stackit.chat_manage_service.Repository.AnswerRepository;
+import com.stackit.chat_manage_service.Repository.NotificationRepository;
+import com.stackit.chat_manage_service.Repository.QuestionRepository;
+import com.stackit.chat_manage_service.Repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+    private final QuestionRepository questionRepository;
+    private final AnswerRepository answerRepository;
+    private final WebSocketService webSocketService;
+
+    @Value("${app.notification.max-unread:100}")
+    private int maxUnreadNotifications;
+
+    @Value("${app.notification.cleanup-days:90}")
+    private int cleanupDays;
+
+    public void createQuestionAnsweredNotification(Long questionId, Long triggeredByUserId) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new RuntimeException("Question not found"));
+
+        User triggeredByUser = userRepository.findById(triggeredByUserId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        // Don't create notification if user is answering their own question
+        if (question.getUser().getId().equals(triggeredByUserId)) {
+            return;
+        }
+
+        // Check if notification already exists to avoid duplicates
+        if (notificationRepository.existsByUserAndReferenceIdAndType(
+                question.getUser(), questionId, NotificationType.QUESTION_ANSWERED)) {
+            return;
+        }
+
+        String message = String.format("%s answered your question: \"%s\"",
+                triggeredByUser.getDisplayName() != null ? triggeredByUser.getDisplayName() : triggeredByUser.getUsername(),
+                truncateTitle(question.getTitle()));
+
+        Notification notification = createNotification(
+                question.getUser(),
+                NotificationType.QUESTION_ANSWERED,
+                message,
+                questionId,
+                "QUESTION",
+                "/questions/" + questionId,
+                triggeredByUser
+        );
+
+        // Send real-time notification
+        webSocketService.sendNotificationToUser(question.getUser().getId(), mapToNotificationResponse(notification));
+    }
+
+    public void createAnswerAcceptedNotification(Long answerId, Long triggeredByUserId) {
+        Answer answer = answerRepository.findByIdAndIsActiveTrue(answerId)
+                .orElseThrow(() -> new RuntimeException("Answer not found"));
+
+        User triggeredByUser = userRepository.findById(triggeredByUserId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        // Don't create notification if user is accepting their own answer
+        if (answer.getUser().getId().equals(triggeredByUserId)) {
+            return;
+        }
+
+        String message = String.format("Your answer to \"%s\" was accepted!",
+                truncateTitle(answer.getQuestion().getTitle()));
+
+        Notification notification = createNotification(
+                answer.getUser(),
+                NotificationType.ANSWER_ACCEPTED,
+                message,
+                answerId,
+                "ANSWER",
+                "/questions/" + answer.getQuestion().getId() + "#answer-" + answerId,
+                triggeredByUser
+        );
+
+        // Send real-time notification
+        webSocketService.sendNotificationToUser(answer.getUser().getId(), mapToNotificationResponse(notification));
+    }
+
+    public void createAnswerUpvotedNotification(Long answerId, Long triggeredByUserId) {
+        Answer answer = answerRepository.findByIdAndIsActiveTrue(answerId)
+                .orElseThrow(() -> new RuntimeException("Answer not found"));
+
+        User triggeredByUser = userRepository.findById(triggeredByUserId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        // Don't create notification if user is voting on their own answer
+        if (answer.getUser().getId().equals(triggeredByUserId)) {
+            return;
+        }
+
+        String message = String.format("Your answer to \"%s\" received an upvote!",
+                truncateTitle(answer.getQuestion().getTitle()));
+
+        Notification notification = createNotification(
+                answer.getUser(),
+                NotificationType.ANSWER_UPVOTED,
+                message,
+                answerId,
+                "ANSWER",
+                "/questions/" + answer.getQuestion().getId() + "#answer-" + answerId,
+                triggeredByUser
+        );
+
+        // Send real-time notification
+        webSocketService.sendNotificationToUser(answer.getUser().getId(), mapToNotificationResponse(notification));
+    }
+
+    public void createAnswerDownvotedNotification(Long answerId, Long triggeredByUserId) {
+        Answer answer = answerRepository.findByIdAndIsActiveTrue(answerId)
+                .orElseThrow(() -> new RuntimeException("Answer not found"));
+
+        User triggeredByUser = userRepository.findById(triggeredByUserId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        // Don't create notification if user is voting on their own answer
+        if (answer.getUser().getId().equals(triggeredByUserId)) {
+            return;
+        }
+
+        String message = String.format("Your answer to \"%s\" received a downvote.",
+                truncateTitle(answer.getQuestion().getTitle()));
+
+        Notification notification = createNotification(
+                answer.getUser(),
+                NotificationType.ANSWER_DOWNVOTED,
+                message,
+                answerId,
+                "ANSWER",
+                "/questions/" + answer.getQuestion().getId() + "#answer-" + answerId,
+                triggeredByUser
+        );
+
+        // Send real-time notification
+        webSocketService.sendNotificationToUser(answer.getUser().getId(), mapToNotificationResponse(notification));
+    }
+
+    public void createUserMentionedNotification(Long mentionedUserId, Long triggeredByUserId, String content, Long referenceId, String referenceType) {
+        User mentionedUser = userRepository.findById(mentionedUserId)
+                .orElseThrow(() -> new RuntimeException("Mentioned user not found"));
+
+        User triggeredByUser = userRepository.findById(triggeredByUserId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        // Don't create notification if user mentions themselves
+        if (mentionedUserId.equals(triggeredByUserId)) {
+            return;
+        }
+
+        String message = String.format("%s mentioned you in a %s",
+                triggeredByUser.getDisplayName() != null ? triggeredByUser.getDisplayName() : triggeredByUser.getUsername(),
+                referenceType.toLowerCase());
+
+        String actionUrl = referenceType.equals("QUESTION") ?
+                "/questions/" + referenceId :
+                "/questions/" + referenceId; // Adjust based on your URL structure
+
+        Notification notification = createNotification(
+                mentionedUser,
+                NotificationType.USER_MENTIONED,
+                message,
+                referenceId,
+                referenceType,
+                actionUrl,
+                triggeredByUser
+        );
+
+        // Send real-time notification
+        webSocketService.sendNotificationToUser(mentionedUserId, mapToNotificationResponse(notification));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<NotificationResponse> getUserNotifications(Long userId, Pageable pageable) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        return notificationRepository.findByUserOrderByCreatedAtDesc(user, pageable)
+                .map(this::mapToNotificationResponse);
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationResponse> getUnreadNotifications(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        return notificationRepository.findByUserAndIsReadFalseOrderByCreatedAtDesc(user)
+                .stream()
+                .map(this::mapToNotificationResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public long getUnreadNotificationCount(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        return notificationRepository.countUnreadByUser(user);
+    }
+
+    public void markNotificationAsRead(Long notificationId, Long userId) {
+        // Verify notification belongs to user
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new RuntimeException("Notification not found"));
+
+        if (!notification.getUser().getId().equals(userId)) {
+            throw new RuntimeException("Not authorized to mark this notification as read");
+        }
+
+        if (!notification.getIsRead()) {
+            notificationRepository.markAsRead(notificationId, LocalDateTime.now());
+            log.info("Notification {} marked as read", notificationId);
+        }
+    }
+
+    public void markAllNotificationsAsRead(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        notificationRepository.markAllAsReadForUser(user, LocalDateTime.now());
+        log.info("All notifications marked as read for user: {}", userId);
+    }
+
+    public void cleanupOldNotifications() {
+        LocalDateTime cutoffDate = LocalDateTime.now().minusDays(cleanupDays);
+        notificationRepository.deleteOldNotifications(cutoffDate);
+        log.info("Cleaned up notifications older than {} days", cleanupDays);
+    }
+
+    private Notification createNotification(User user, NotificationType type, String message,
+                                            Long referenceId, String referenceType, String actionUrl,
+                                            User triggeredByUser) {
+
+        // Limit unread notifications per user
+        long unreadCount = notificationRepository.countUnreadByUser(user);
+        if (unreadCount >= maxUnreadNotifications) {
+            log.warn("User {} has reached maximum unread notifications limit", user.getId());
+            return null;
+        }
+
+        Notification notification = Notification.builder()
+                .user(user)
+                .type(type)
+                .message(message)
+                .referenceId(referenceId)
+                .referenceType(referenceType)
+                .actionUrl(actionUrl)
+                .triggeredByUser(triggeredByUser)
+                .build();
+
+        return notificationRepository.save(notification);
+    }
+
+    private String truncateTitle(String title) {
+        if (title.length() > 50) {
+            return title.substring(0, 47) + "...";
+        }
+        return title;
+    }
+
+    private NotificationResponse mapToNotificationResponse(Notification notification) {
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .type(notification.getType())
+                .message(notification.getMessage())
+                .referenceId(notification.getReferenceId())
+                .referenceType(notification.getReferenceType())
+                .isRead(notification.getIsRead())
+                .readAt(notification.getReadAt())
+                .actionUrl(notification.getActionUrl())
+                .createdAt(notification.getCreatedAt())
+                .triggeredByUser(notification.getTriggeredByUser() != null ?
+                        mapToUserSummary(notification.getTriggeredByUser()) : null)
+                .build();
+    }
+
+    private UserSummaryResponse mapToUserSummary(User user) {
+        return UserSummaryResponse.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .displayName(user.getDisplayName())
+                .role(user.getRole())
+                .avatarUrl(user.getAvatarUrl())
+                .reputationScore(user.getReputationScore())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Service/QuestionService.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Service/QuestionService.java
@@ -1,0 +1,275 @@
+package com.stackit.chat_manage_service.Service;
+
+import com.stackit.chat_manage_service.Payload.Request.CreateQuestionRequest;
+import com.stackit.chat_manage_service.Payload.Response.QuestionResponse;
+import com.stackit.chat_manage_service.Payload.Response.TagResponse;
+import com.stackit.chat_manage_service.Payload.Response.UserSummaryResponse;
+import com.stackit.chat_manage_service.Repository.QuestionRepository;
+import com.stackit.chat_manage_service.Repository.TagRepository;
+import com.stackit.chat_manage_service.Repository.UserRepository;
+import com.stackit.chat_manage_service.Entity.Question;
+import com.stackit.chat_manage_service.Entity.Tag;
+import com.stackit.chat_manage_service.Entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class QuestionService {
+
+    private final QuestionRepository questionRepository;
+    private final UserRepository userRepository;
+    private final TagRepository tagRepository;
+    private final TagService tagService;
+    private final WebSocketService webSocketService;
+    private final NotificationService notificationService;
+
+    @Value("${app.richtext.max-length:50000}")
+    private int maxContentLength;
+
+    public QuestionResponse createQuestion(CreateQuestionRequest request) {
+        log.info("Creating question: {}", request.getTitle());
+
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        // Validate and sanitize content
+        String sanitizedDescription = sanitizeHtmlContent(request.getDescription());
+        if (sanitizedDescription.length() > maxContentLength) {
+            throw new RuntimeException("Content exceeds maximum length");
+        }
+
+        // Process tags
+        Set<Tag> tags = processTags(request.getTags());
+
+        Question question = Question.builder()
+                .title(request.getTitle().trim())
+                .description(sanitizedDescription)
+                .user(user)
+                .tags(tags)
+                .build();
+
+        Question savedQuestion = questionRepository.save(question);
+
+        // Update tag usage counts
+        tags.forEach(tag -> tagRepository.incrementUsageCount(tag.getId()));
+
+        QuestionResponse response = mapToQuestionResponse(savedQuestion);
+
+        // Send WebSocket notification
+        webSocketService.broadcastQuestionCreated(response);
+
+        log.info("Question created successfully with ID: {}", savedQuestion.getId());
+        return response;
+    }
+
+    @Transactional(readOnly = true)
+    public QuestionResponse getQuestionById(Long id, Long currentUserId) {
+        Question question = questionRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Question not found"));
+
+        // Increment view count if not the question owner
+        if (currentUserId == null || !question.getUser().getId().equals(currentUserId)) {
+            questionRepository.incrementViewCount(id);
+        }
+
+        return mapToQuestionResponse(question);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<QuestionResponse> getAllQuestions(Pageable pageable) {
+        return questionRepository.findByIsActiveTrueOrderByCreatedAtDesc(pageable)
+                .map(this::mapToQuestionResponse);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<QuestionResponse> searchQuestions(String keyword, Pageable pageable) {
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return getAllQuestions(pageable);
+        }
+
+        return questionRepository.findByKeyword(keyword.trim(), pageable)
+                .map(this::mapToQuestionResponse);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<QuestionResponse> getQuestionsByTags(List<String> tagNames, Pageable pageable) {
+        List<Tag> tags = tagNames.stream()
+                .map(name -> tagRepository.findByName(name)
+                        .orElseThrow(() -> new RuntimeException("Tag not found: " + name)))
+                .toList();
+
+        return questionRepository.findByTags(tags, pageable)
+                .map(this::mapToQuestionResponse);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<QuestionResponse> getUnansweredQuestions(Pageable pageable) {
+        return questionRepository.findUnansweredQuestions(pageable)
+                .map(this::mapToQuestionResponse);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<QuestionResponse> getRecentQuestions(int days, Pageable pageable) {
+        LocalDateTime since = LocalDateTime.now().minusDays(days);
+        return questionRepository.findRecentQuestions(since, pageable)
+                .map(this::mapToQuestionResponse);
+    }
+
+    public QuestionResponse updateQuestion(Long id, CreateQuestionRequest request, Long currentUserId) {
+        Question question = questionRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Question not found"));
+
+        if (!question.getUser().getId().equals(currentUserId)) {
+            throw new RuntimeException("Not authorized to update this question");
+        }
+
+        // Update basic fields
+        question.setTitle(request.getTitle().trim());
+        question.setDescription(sanitizeHtmlContent(request.getDescription()));
+
+        // Update tags
+        Set<Tag> oldTags = new HashSet<>(question.getTags());
+        Set<Tag> newTags = processTags(request.getTags());
+
+        // Decrement usage count for removed tags
+        oldTags.stream()
+                .filter(tag -> !newTags.contains(tag))
+                .forEach(tag -> tagRepository.decrementUsageCount(tag.getId()));
+
+        // Increment usage count for new tags
+        newTags.stream()
+                .filter(tag -> !oldTags.contains(tag))
+                .forEach(tag -> tagRepository.incrementUsageCount(tag.getId()));
+
+        question.setTags(newTags);
+
+        Question savedQuestion = questionRepository.save(question);
+        QuestionResponse response = mapToQuestionResponse(savedQuestion);
+
+        // Send WebSocket notification
+        webSocketService.broadcastQuestionUpdated(response);
+
+        return response;
+    }
+
+    public void acceptAnswer(Long questionId, Long answerId, Long currentUserId) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new RuntimeException("Question not found"));
+
+        if (!question.getUser().getId().equals(currentUserId)) {
+            throw new RuntimeException("Only question owner can accept answers");
+        }
+
+        questionRepository.updateAcceptedAnswer(questionId, answerId);
+
+        // Send WebSocket notification
+        webSocketService.broadcastAnswerAccepted(questionId, answerId);
+
+        // Create notification for answer author
+        notificationService.createAnswerAcceptedNotification(answerId, currentUserId);
+    }
+
+    public void deleteQuestion(Long id, Long currentUserId) {
+        Question question = questionRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Question not found"));
+
+        if (!question.getUser().getId().equals(currentUserId)) {
+            throw new RuntimeException("Not authorized to delete this question");
+        }
+
+        question.setIsActive(false);
+        questionRepository.save(question);
+
+        // Decrement tag usage counts
+        question.getTags().forEach(tag -> tagRepository.decrementUsageCount(tag.getId()));
+
+        log.info("Question deleted: {}", id);
+    }
+
+    private Set<Tag> processTags(Set<String> tagNames) {
+        Set<Tag> tags = new HashSet<>();
+
+        for (String tagName : tagNames) {
+            String normalizedName = tagName.trim().toLowerCase();
+            Tag tag = tagRepository.findByName(normalizedName)
+                    .orElseGet(() -> tagService.createTag(normalizedName));
+            tags.add(tag);
+        }
+
+        return tags;
+    }
+
+    private String sanitizeHtmlContent(String content) {
+        // This is a simplified sanitization - in production, use a proper HTML sanitizer like OWASP Java HTML Sanitizer
+        return content.trim();
+    }
+
+    private QuestionResponse mapToQuestionResponse(Question question) {
+        // Safely handle tags collection
+        Set<TagResponse> tagResponses = new HashSet<>();
+        if (question.getTags() != null) {
+            try {
+                for (Tag tag : question.getTags()) {
+                    tagResponses.add(mapToTagResponse(tag));
+                }
+            } catch (Exception e) {
+                log.warn("Error processing tags for question {}: {}", question.getId(), e.getMessage());
+                // Continue with empty tags set
+            }
+        }
+
+        return QuestionResponse.builder()
+                .id(question.getId())
+                .title(question.getTitle())
+                .description(question.getDescription())
+                .viewCount(question.getViewCount())
+                .isActive(question.getIsActive())
+                .isClosed(question.getIsClosed())
+                .closeReason(question.getCloseReason())
+                .acceptedAnswerId(question.getAcceptedAnswerId())
+                .createdAt(question.getCreatedAt())
+                .updatedAt(question.getUpdatedAt())
+                .user(mapToUserSummary(question.getUser()))
+                .tags(tagResponses)
+                .answerCount(question.getAnswers() != null ? question.getAnswers().size() : 0)
+                .hasAcceptedAnswer(question.getAcceptedAnswerId() != null)
+                .build();
+    }
+
+    private UserSummaryResponse mapToUserSummary(User user) {
+        return UserSummaryResponse.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .displayName(user.getDisplayName())
+                .role(user.getRole())
+                .avatarUrl(user.getAvatarUrl())
+                .reputationScore(user.getReputationScore())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+
+    private TagResponse mapToTagResponse(Tag tag) {
+        return TagResponse.builder()
+                .id(tag.getId())
+                .name(tag.getName())
+                .description(tag.getDescription())
+                .usageCount(tag.getUsageCount())
+                .isActive(tag.getIsActive())
+                .colorCode(tag.getColorCode())
+                .createdAt(tag.getCreatedAt())
+                .build();
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Service/TagService.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Service/TagService.java
@@ -1,0 +1,142 @@
+package com.stackit.chat_manage_service.Service;
+
+import com.stackit.chat_manage_service.Entity.Tag;
+import com.stackit.chat_manage_service.Payload.Response.TagResponse;
+import com.stackit.chat_manage_service.Repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class TagService {
+
+    private final TagRepository tagRepository;
+
+    private static final String[] COLORS = {
+            "#3B82F6", "#EF4444", "#10B981", "#F59E0B", "#8B5CF6",
+            "#06B6D4", "#84CC16", "#F97316", "#EC4899", "#6366F1"
+    };
+
+    public Tag createTag(String name) {
+        log.info("Creating new tag: {}", name);
+
+        String normalizedName = name.trim().toLowerCase();
+
+        if (tagRepository.existsByName(normalizedName)) {
+            throw new RuntimeException("Tag already exists: " + normalizedName);
+        }
+
+        // Generate random color for the tag
+        String colorCode = COLORS[new Random().nextInt(COLORS.length)];
+
+        Tag tag = Tag.builder()
+                .name(normalizedName)
+                .colorCode(colorCode)
+                .isActive(true)
+                .usageCount(0)
+                .build();
+
+        Tag savedTag = tagRepository.save(tag);
+        log.info("Tag created successfully: {}", savedTag.getName());
+
+        return savedTag;
+    }
+
+    @Transactional(readOnly = true)
+    public List<TagResponse> searchTags(String keyword) {
+        List<Tag> tags;
+
+        if (keyword == null || keyword.trim().isEmpty()) {
+            tags = tagRepository.findActiveTags();
+        } else {
+            tags = tagRepository.findByKeyword(keyword.trim());
+        }
+
+        return tags.stream()
+                .map(this::mapToTagResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<TagResponse> getAllTags(Pageable pageable) {
+        return tagRepository.findByIsActiveTrueOrderByUsageCountDesc(pageable)
+                .map(this::mapToTagResponse);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TagResponse> getMostUsedTags(int limit) {
+        Pageable pageable = org.springframework.data.domain.PageRequest.of(0, limit);
+        return tagRepository.findMostUsedTags(pageable)
+                .stream()
+                .map(this::mapToTagResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public TagResponse getTagById(Long id) {
+        Tag tag = tagRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Tag not found"));
+
+        return mapToTagResponse(tag);
+    }
+
+    @Transactional(readOnly = true)
+    public TagResponse getTagByName(String name) {
+        Tag tag = tagRepository.findByName(name.trim().toLowerCase())
+                .orElseThrow(() -> new RuntimeException("Tag not found: " + name));
+
+        return mapToTagResponse(tag);
+    }
+
+    public TagResponse updateTag(Long id, String description, String colorCode) {
+        Tag tag = tagRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Tag not found"));
+
+        if (description != null && !description.trim().isEmpty()) {
+            tag.setDescription(description.trim());
+        }
+
+        if (colorCode != null && !colorCode.trim().isEmpty()) {
+            tag.setColorCode(colorCode.trim());
+        }
+
+        Tag savedTag = tagRepository.save(tag);
+        return mapToTagResponse(savedTag);
+    }
+
+    public void deactivateTag(Long id) {
+        Tag tag = tagRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Tag not found"));
+
+        tag.setIsActive(false);
+        tagRepository.save(tag);
+
+        log.info("Tag deactivated: {}", tag.getName());
+    }
+
+    @Transactional(readOnly = true)
+    public long getTagCount() {
+        return tagRepository.countActiveTags();
+    }
+
+    private TagResponse mapToTagResponse(Tag tag) {
+        return TagResponse.builder()
+                .id(tag.getId())
+                .name(tag.getName())
+                .description(tag.getDescription())
+                .usageCount(tag.getUsageCount())
+                .isActive(tag.getIsActive())
+                .colorCode(tag.getColorCode())
+                .createdAt(tag.getCreatedAt())
+                .build();
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Service/VoteService.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Service/VoteService.java
@@ -1,0 +1,151 @@
+package com.stackit.chat_manage_service.Service;
+
+import com.stackit.chat_manage_service.Entity.Answer;
+import com.stackit.chat_manage_service.Entity.User;
+import com.stackit.chat_manage_service.Entity.Vote;
+import com.stackit.chat_manage_service.Entity.enums.VoteType;
+import com.stackit.chat_manage_service.Payload.Request.VoteRequest;
+import com.stackit.chat_manage_service.Repository.AnswerRepository;
+import com.stackit.chat_manage_service.Repository.UserRepository;
+import com.stackit.chat_manage_service.Repository.VoteRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class VoteService {
+
+    private final VoteRepository voteRepository;
+    private final AnswerRepository answerRepository;
+    private final UserRepository userRepository;
+    private final WebSocketService webSocketService;
+    private final NotificationService notificationService;
+
+    public void voteOnAnswer(Long answerId, VoteRequest request) {
+        log.info("Processing vote on answer: {}", answerId);
+
+        Answer answer = answerRepository.findByIdAndIsActiveTrue(answerId)
+                .orElseThrow(() -> new RuntimeException("Answer not found"));
+
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        // Prevent users from voting on their own answers
+        if (answer.getUser().getId().equals(user.getId())) {
+            throw new RuntimeException("Cannot vote on your own answer");
+        }
+
+        Optional<Vote> existingVote = voteRepository.findByUserAndAnswer(user, answer);
+
+        if (existingVote.isPresent()) {
+            Vote vote = existingVote.get();
+
+            if (vote.getVoteType() == request.getVoteType()) {
+                // Remove vote if same type is clicked again
+                voteRepository.delete(vote);
+                log.info("Vote removed for answer: {}", answerId);
+            } else {
+                // Change vote type
+                vote.setVoteType(request.getVoteType());
+                voteRepository.save(vote);
+                log.info("Vote changed for answer: {}", answerId);
+            }
+        } else {
+            // Create new vote
+            Vote newVote = Vote.builder()
+                    .user(user)
+                    .answer(answer)
+                    .voteType(request.getVoteType())
+                    .build();
+
+            voteRepository.save(newVote);
+            log.info("New vote created for answer: {}", answerId);
+        }
+
+        // Calculate new score
+        int newScore = calculateAnswerScore(answer);
+
+        // Send WebSocket notification about score change
+        webSocketService.broadcastVoteChange(answerId, newScore);
+
+        // Create notification for answer author (if not voting on own answer)
+        if (!answer.getUser().getId().equals(user.getId())) {
+            if (request.getVoteType() == VoteType.UPVOTE) {
+                notificationService.createAnswerUpvotedNotification(answerId, user.getId());
+            } else {
+                notificationService.createAnswerDownvotedNotification(answerId, user.getId());
+            }
+        }
+    }
+
+    public void removeVote(Long answerId, Long userId) {
+        log.info("Removing vote on answer: {} by user: {}", answerId, userId);
+
+        Answer answer = answerRepository.findByIdAndIsActiveTrue(answerId)
+                .orElseThrow(() -> new RuntimeException("Answer not found"));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        voteRepository.findByUserAndAnswer(user, answer)
+                .ifPresent(vote -> {
+                    voteRepository.delete(vote);
+
+                    // Calculate new score
+                    int newScore = calculateAnswerScore(answer);
+
+                    // Send WebSocket notification about score change
+                    webSocketService.broadcastVoteChange(answerId, newScore);
+
+                    log.info("Vote removed successfully");
+                });
+    }
+
+    @Transactional(readOnly = true)
+    public int getAnswerScore(Long answerId) {
+        Answer answer = answerRepository.findByIdAndIsActiveTrue(answerId)
+                .orElseThrow(() -> new RuntimeException("Answer not found"));
+
+        return calculateAnswerScore(answer);
+    }
+
+    @Transactional(readOnly = true)
+    public VoteType getUserVoteForAnswer(Long answerId, Long userId) {
+        Answer answer = answerRepository.findByIdAndIsActiveTrue(answerId)
+                .orElseThrow(() -> new RuntimeException("Answer not found"));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        return voteRepository.findByUserAndAnswer(user, answer)
+                .map(Vote::getVoteType)
+                .orElse(null);
+    }
+
+    @Transactional(readOnly = true)
+    public long getUpvoteCount(Long answerId) {
+        Answer answer = answerRepository.findByIdAndIsActiveTrue(answerId)
+                .orElseThrow(() -> new RuntimeException("Answer not found"));
+
+        return voteRepository.countUpvotesByAnswer(answer);
+    }
+
+    @Transactional(readOnly = true)
+    public long getDownvoteCount(Long answerId) {
+        Answer answer = answerRepository.findByIdAndIsActiveTrue(answerId)
+                .orElseThrow(() -> new RuntimeException("Answer not found"));
+
+        return voteRepository.countDownvotesByAnswer(answer);
+    }
+
+    private int calculateAnswerScore(Answer answer) {
+        Integer score = voteRepository.calculateScoreByAnswer(answer);
+        return score != null ? score : 0;
+    }
+}

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Service/WebSocketService.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Service/WebSocketService.java
@@ -1,0 +1,172 @@
+package com.stackit.chat_manage_service.Service;
+
+import com.stackit.chat_manage_service.Payload.Response.AnswerResponse;
+import com.stackit.chat_manage_service.Payload.Response.NotificationResponse;
+import com.stackit.chat_manage_service.Payload.Response.QuestionResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketService {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    /**
+     * Broadcast a new question to all connected clients
+     */
+    public void broadcastQuestionCreated(QuestionResponse question) {
+        log.info("Broadcasting new question: {}", question.getId());
+
+        Map<String, Object> message = new HashMap<>();
+        message.put("type", "QUESTION_CREATED");
+        message.put("data", question);
+
+        messagingTemplate.convertAndSend("/topic/questions", message);
+    }
+
+    /**
+     * Broadcast question updates to all subscribers
+     */
+    public void broadcastQuestionUpdated(QuestionResponse question) {
+        log.info("Broadcasting question update: {}", question.getId());
+
+        Map<String, Object> message = new HashMap<>();
+        message.put("type", "QUESTION_UPDATED");
+        message.put("data", question);
+
+        messagingTemplate.convertAndSend("/topic/questions/" + question.getId(), message);
+        messagingTemplate.convertAndSend("/topic/questions", message);
+    }
+
+    /**
+     * Broadcast new answer to question subscribers
+     */
+    public void broadcastNewAnswer(AnswerResponse answer) {
+        log.info("Broadcasting new answer: {} for question: {}", answer.getId(), answer.getQuestionId());
+
+        Map<String, Object> message = new HashMap<>();
+        message.put("type", "NEW_ANSWER");
+        message.put("data", answer);
+
+        messagingTemplate.convertAndSend("/topic/questions/" + answer.getQuestionId(), message);
+    }
+
+    /**
+     * Broadcast answer updates to question subscribers
+     */
+    public void broadcastAnswerUpdated(AnswerResponse answer) {
+        log.info("Broadcasting answer update: {} for question: {}", answer.getId(), answer.getQuestionId());
+
+        Map<String, Object> message = new HashMap<>();
+        message.put("type", "ANSWER_UPDATED");
+        message.put("data", answer);
+
+        messagingTemplate.convertAndSend("/topic/questions/" + answer.getQuestionId(), message);
+    }
+
+    /**
+     * Broadcast answer acceptance to question subscribers
+     */
+    public void broadcastAnswerAccepted(Long questionId, Long answerId) {
+        log.info("Broadcasting answer acceptance: {} for question: {}", answerId, questionId);
+
+        Map<String, Object> message = new HashMap<>();
+        message.put("type", "ANSWER_ACCEPTED");
+        message.put("questionId", questionId);
+        message.put("answerId", answerId);
+
+        messagingTemplate.convertAndSend("/topic/questions/" + questionId, message);
+    }
+
+    /**
+     * Broadcast vote changes to question subscribers
+     */
+    public void broadcastVoteChange(Long answerId, int newScore) {
+        log.info("Broadcasting vote change for answer: {} with new score: {}", answerId, newScore);
+
+        Map<String, Object> message = new HashMap<>();
+        message.put("type", "VOTE_CHANGED");
+        message.put("answerId", answerId);
+        message.put("newScore", newScore);
+
+        messagingTemplate.convertAndSend("/topic/answers/" + answerId, message);
+    }
+
+    /**
+     * Send private notification to a specific user
+     */
+    public void sendNotificationToUser(Long userId, NotificationResponse notification) {
+        log.info("Sending notification to user: {}", userId);
+
+        Map<String, Object> message = new HashMap<>();
+        message.put("type", "NEW_NOTIFICATION");
+        message.put("data", notification);
+
+        messagingTemplate.convertAndSendToUser(userId.toString(), "/queue/notifications", message);
+    }
+
+    /**
+     * Broadcast typing indicator for a question
+     */
+    public void broadcastTypingIndicator(Long questionId, String username, boolean isTyping) {
+        log.debug("Broadcasting typing indicator for question: {} user: {} typing: {}",
+                questionId, username, isTyping);
+
+        Map<String, Object> message = new HashMap<>();
+        message.put("type", "TYPING_INDICATOR");
+        message.put("username", username);
+        message.put("isTyping", isTyping);
+
+        messagingTemplate.convertAndSend("/topic/questions/" + questionId + "/typing", message);
+    }
+
+    /**
+     * Broadcast user online status
+     */
+    public void broadcastUserOnlineStatus(Long userId, boolean isOnline) {
+        log.debug("Broadcasting user online status: {} online: {}", userId, isOnline);
+
+        Map<String, Object> message = new HashMap<>();
+        message.put("type", "USER_STATUS");
+        message.put("userId", userId);
+        message.put("isOnline", isOnline);
+
+        messagingTemplate.convertAndSend("/topic/users/status", message);
+    }
+
+    /**
+     * Send system-wide announcements
+     */
+    public void broadcastSystemAnnouncement(String title, String message, String type) {
+        log.info("Broadcasting system announcement: {}", title);
+
+        Map<String, Object> announcement = new HashMap<>();
+        announcement.put("type", "SYSTEM_ANNOUNCEMENT");
+        announcement.put("title", title);
+        announcement.put("message", message);
+        announcement.put("announcementType", type); // INFO, WARNING, ERROR
+        announcement.put("timestamp", System.currentTimeMillis());
+
+        messagingTemplate.convertAndSend("/topic/announcements", announcement);
+    }
+
+    /**
+     * Send real-time statistics updates
+     */
+    public void broadcastStatisticsUpdate(Map<String, Object> stats) {
+        log.debug("Broadcasting statistics update");
+
+        Map<String, Object> message = new HashMap<>();
+        message.put("type", "STATISTICS_UPDATE");
+        message.put("data", stats);
+
+        messagingTemplate.convertAndSend("/topic/statistics", message);
+    }
+}

--- a/Backend/chat-manage-service/src/main/resources/application.properties
+++ b/Backend/chat-manage-service/src/main/resources/application.properties
@@ -1,1 +1,59 @@
 spring.application.name=chat-manage-service
+server.port=${PORT:7000}
+server.servlet.context-path=/api
+
+# Database configuration
+spring.datasource.url=${DB_URL:jdbc:mysql://localhost:3306/stackIt_db?createDatabaseIfNotExist=true}
+spring.datasource.username=${DB_USERNAME:root}
+spring.datasource.password=${DB_PASSWORD:Vandit@2512}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=update
+
+# File Upload Configuration
+spring.servlet.multipart.enabled=true
+spring.servlet.multipart.file-size-threshold=2KB
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=15MB
+
+# File Storage Configuration
+app.file.upload-dir=./uploads
+app.file.max-size=10485760
+app.file.allowed-types=image/jpeg,image/png,image/gif,image/webp
+
+# WebSocket Configuration
+app.websocket.allowed-origins=http://localhost:3000,https://stackit-frontend.com
+
+# Pagination Configuration
+app.pagination.default-page-size=20
+app.pagination.max-page-size=100
+
+# Rich Text Configuration
+app.richtext.max-length=50000
+app.richtext.allowed-tags=p,br,strong,em,u,s,ul,ol,li,h1,h2,h3,h4,h5,h6,blockquote,a,img,code,pre
+
+# Notification Configuration
+app.notification.max-unread=100
+app.notification.cleanup-days=90
+
+# API Documentation
+# Swagger UI Configuration for Spring Boot 3.5.3
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.api-docs.path=/api-docs
+
+# CORS Configuration for Swagger UI
+springdoc.swagger-ui.csrf.enabled=false
+springdoc.swagger-ui.operations-sorter=alpha
+springdoc.swagger-ui.tags-sorter=alpha
+
+# Logging Configuration
+logging.level.com.stackit=DEBUG
+logging.level.org.springframework.web=DEBUG
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+
+# Actuator Configuration
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
+management.endpoint.health.show-details=when-authorized
+management.prometheus.metrics.export.enabled=true


### PR DESCRIPTION
Introduces main entities (User, Question, Answer, Tag, Notification, Vote), enums, repositories, services, and REST controllers for a StackIt Q&A platform. Adds configuration for OpenAPI, WebSocket, JPA, and file upload. Updates .gitignore and pom.xml to support new dependencies and features. Enables auditing, async, and transaction management in the application entry point.