### PR TITLE
Enhance question search and view count logic

### DIFF
--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/ChatManageServiceApplication.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/ChatManageServiceApplication.java
@@ -4,13 +4,17 @@ import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableAsync
 @EnableTransactionManagement
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 public class ChatManageServiceApplication {
 
 	public static void main(String[] args) {

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Repository/QuestionRepository.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Repository/QuestionRepository.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
@@ -27,9 +26,9 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     Page<Question> findByTitleContainingIgnoreCaseAndIsActiveTrue(String title, Pageable pageable);
 
-    @Query("SELECT q FROM Question q WHERE q.isActive = true AND " +
+    @Query("SELECT DISTINCT q FROM Question q LEFT JOIN FETCH q.tags LEFT JOIN FETCH q.user WHERE q.isActive = true AND " +
             "(LOWER(q.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
-            "LOWER(q.description) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+            "LOWER(q.description) LIKE LOWER(CONCAT('%', :keyword, '%'))) ORDER BY q.createdAt DESC")
     Page<Question> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
 
     @Query("SELECT q FROM Question q JOIN q.tags t WHERE t IN :tags AND q.isActive = true")

--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Service/QuestionService.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Service/QuestionService.java
@@ -81,7 +81,7 @@ public class QuestionService {
                 .orElseThrow(() -> new RuntimeException("Question not found"));
 
         // Increment view count if not the question owner
-        if (currentUserId == null || !question.getUser().getId().equals(currentUserId)) {
+        if (!question.getUser().getId().equals(currentUserId)) {
             questionRepository.incrementViewCount(id);
         }
 

--- a/Backend/chat-manage-service/src/main/resources/application.properties
+++ b/Backend/chat-manage-service/src/main/resources/application.properties
@@ -8,6 +8,7 @@ spring.datasource.username=${DB_USERNAME:root}
 spring.datasource.password=${DB_PASSWORD:Vandit@2512}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=false
 
 # File Upload Configuration
 spring.servlet.multipart.enabled=true


### PR DESCRIPTION
Updated QuestionRepository to fetch distinct questions with tags and user, and order by creation date in keyword search. Modified QuestionService to increment view count only if the current user is not the question owner. Enabled DTO-based page serialization and disabled SQL logging in application properties.