### PR TITLE
Update WebSocket config for dynamic origins and endpoint

### DIFF
--- a/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Config/WebSocketConfig.java
+++ b/Backend/chat-manage-service/src/main/java/com/stackit/chat_manage_service/Config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.stackit.chat_manage_service.Config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
@@ -16,23 +17,33 @@ import java.util.List;
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    @Value("${app.websocket.allowed-origins:http://localhost:3000}")
+    private String allowedOrigins;
+
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
-        config.enableSimpleBroker("/topic");
+        // Enable a simple memory-based message broker
+        config.enableSimpleBroker("/topic", "/queue");
+
+        // Prefix for messages bound for @MessageMapping methods
         config.setApplicationDestinationPrefixes("/app");
+
+        // Prefix for user-specific destinations
+        config.setUserDestinationPrefix("/user");
     }
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/chat")
-                .setAllowedOrigins("http://localhost:5174","http://localhost:5173","http://localhost:1818")
+        // WebSocket endpoint that clients will use to connect
+        registry.addEndpoint("/ws")
+                .setAllowedOrigins(allowedOrigins.split(","))
                 .withSockJS();
     }
 
     @Bean
     public UrlBasedCorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:5173","http://localhost:4028"));
+        configuration.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:4028"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Accept"));
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
WebSocket endpoint changed to '/ws' and allowed origins are now configurable via application properties. Added support for '/queue' and '/user' prefixes in message broker, improving flexibility for user-specific messaging.